### PR TITLE
yum: ipaserver_packages should have brackets

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Ensure software is installed (yum)
   yum: name={{ item }} state=present
-  with_items: ipaserver_packages
+  with_items: "{{ ipaserver_packages }}"
   when: ansible_distribution == "CentOS" or
         (ansible_distribution == "Fedora" and ansible_distribution_version|int <= 21)
 


### PR DESCRIPTION
Similar to #4 but it needs to be done for yum as well.

@gregswift: After this gets merged, would you mind cutting a release to Ansible Galaxy?