### PR TITLE
Fix regex for adding a host entry

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Add host entry
   lineinfile:
     dest=/etc/hosts
-    regexp=" {{ ansible_hostname }} "
+    regexp=" {{ ansible_fqdn }} ?"
     line="{{ ansible_default_ipv4.address }} {{ ansible_fqdn }}"
     owner=root
     group=root


### PR DESCRIPTION
This PR fixes a bug which leads this task not to be idempotent.

Since the regex _was_ looking for `ansible_hostname` on a line, but then filling the line with `ansible_fqdn`, if those twovariables weren't the same you would continually get lines added to the /etc/hosts file every time this playbook was run.