### PR TITLE
Fix "squash_actions" deprecation warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,14 +12,12 @@
     mode=0644
 
 - name: Ensure software is installed (yum)
-  yum: name={{ item }} state=present
-  with_items: "{{ ipaserver_packages }}"
+  yum: name={{ ipaserver_packages }} state=present
   when: ansible_distribution == "CentOS" or
         (ansible_distribution == "Fedora" and ansible_distribution_version|int <= 21)
 
 - name: Ensure software is installed (dnf)
-  dnf: name={{ item }} state=present
-  with_items: "{{ ipaserver_packages }}"
+  dnf: name={{ ipaserver_packages }} state=present
   when: ansible_distribution == "Fedora" and ansible_distribution_version|int > 21
 
 - name: Run the installer


### PR DESCRIPTION
With the latest Ansible v2.7, we're getting a few deprecation warnings:

```
[DEPRECATION WARNING]: Invoking "dnf" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: {{
item }}`, please use `name: u'{{ ipaserver_packages }}'` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```